### PR TITLE
query fetcher error cleared

### DIFF
--- a/part8/library-frontend/src/components/NewBook.js
+++ b/part8/library-frontend/src/components/NewBook.js
@@ -11,7 +11,10 @@ const NewBook = (props) => {
   const [genres, setGenres] = useState([]);
 
   const [createBook] = useMutation(ADD_BOOK, {
-    refetchQueries: [ {query: ALL_BOOKS}, {query: ALL_AUTHORS} ]
+    refetchQueries: [
+      { query: ALL_BOOKS, variables: { genre: "" } },
+      { query: ALL_AUTHORS },
+    ],
   });
 
   if (!props.show) {
@@ -81,7 +84,6 @@ const NewBook = (props) => {
       </form>
 
       <SetBirthYear />
-      
     </div>
   );
 };


### PR DESCRIPTION
 -  inculde variable in refetching because the display query fetcher
    also uses variable 'genre'